### PR TITLE
Adding functionality for B-Modes

### DIFF
--- a/SMPy/KaiserSquires/example_config.yaml
+++ b/SMPy/KaiserSquires/example_config.yaml
@@ -28,3 +28,6 @@ dec_col: 'dec'                      # Column name for Declination
 g1_col: 'g1_Rinv'                   # Column name for first shear component
 g2_col: 'g2_Rinv'                   # Column name for second shear component
 weight_col: 'weight'  # Column name for data weighting
+
+# Mode
+mode: 'E' # either E or B

--- a/SMPy/KaiserSquires/kaiser_squires.py
+++ b/SMPy/KaiserSquires/kaiser_squires.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-def ks_inversion(g1_grid, g2_grid):
+def ks_e_mode_inversion(g1_grid, g2_grid):
     """
-    Perform the Kaiser-Squires inversion to obtain the convergence map from shear components.
+    Perform the Kaiser-Squires inversion to obtain the E-mode convergence map from shear components.
     """
     # Get the dimensions of the input grids
     npix_dec, npix_ra = g1_grid.shape
@@ -19,7 +19,34 @@ def ks_inversion(g1_grid, g2_grid):
     k_squared = np.where(k_squared == 0, np.finfo(float).eps, k_squared)
 
     # Kaiser-Squires inversion in Fourier space
-    kappa_hat = (1 / k_squared) * ((k1**2 - k2**2) * g1_hat + 2 * k1 * k2 * g2_hat)
+    kappa_hat = (1 / k_squared) * ((k1**2 - k2**2) * g1_hat + 2 * k1**2 * k2**2 * g2_hat)
+
+    # Inverse Fourier transform to get the convergence map
+    kappa_grid = np.fft.ifft2(kappa_hat)
+
+    return np.real(kappa_grid)  # Return the real part
+
+
+def ks_b_mode_inversion(g1_grid, g2_grid):
+    """
+    Perform the Kaiser-Squires inversion to obtain the B-mode convergence map from shear components.
+    """
+    # Get the dimensions of the input grids
+    npix_dec, npix_ra = g1_grid.shape
+
+    # Fourier transform the shear components
+    g1_hat = np.fft.fft2(g1_grid)
+    g2_hat = np.fft.fft2(g2_grid)
+
+    # Create a grid of wave numbers
+    k1, k2 = np.meshgrid(np.fft.fftfreq(npix_ra), np.fft.fftfreq(npix_dec))
+    k_squared = k1**2 + k2**2
+
+    # Avoid division by zero by replacing zero values with a small number
+    k_squared = np.where(k_squared == 0, np.finfo(float).eps, k_squared)
+
+    # Kaiser-Squires inversion in Fourier space
+    kappa_hat = (1 / k_squared) * ((k1**2 - k2**2) * g2_hat - 2 * k1**2 * k2**2 * g1_hat)
 
     # Inverse Fourier transform to get the convergence map
     kappa_grid = np.fft.ifft2(kappa_hat)

--- a/SMPy/KaiserSquires/kaiser_squires.py
+++ b/SMPy/KaiserSquires/kaiser_squires.py
@@ -19,7 +19,7 @@ def ks_e_mode_inversion(g1_grid, g2_grid):
     k_squared = np.where(k_squared == 0, np.finfo(float).eps, k_squared)
 
     # Kaiser-Squires inversion in Fourier space
-    kappa_hat = (1 / k_squared) * ((k1**2 - k2**2) * g1_hat + 2 * k1**2 * k2**2 * g2_hat)
+    kappa_hat = (1 / k_squared) * ((k1**2 - k2**2) * g1_hat + 2 * k1 * k2 * g2_hat)
 
     # Inverse Fourier transform to get the convergence map
     kappa_grid = np.fft.ifft2(kappa_hat)
@@ -46,7 +46,7 @@ def ks_b_mode_inversion(g1_grid, g2_grid):
     k_squared = np.where(k_squared == 0, np.finfo(float).eps, k_squared)
 
     # Kaiser-Squires inversion in Fourier space
-    kappa_hat = (1 / k_squared) * ((k1**2 - k2**2) * g2_hat - 2 * k1**2 * k2**2 * g1_hat)
+    kappa_hat = (1 / k_squared) * ((k1**2 - k2**2) * g2_hat - 2 * k1 * k2 * g1_hat)
 
     # Inverse Fourier transform to get the convergence map
     kappa_grid = np.fft.ifft2(kappa_hat)

--- a/SMPy/KaiserSquires/run.py
+++ b/SMPy/KaiserSquires/run.py
@@ -32,7 +32,13 @@ def create_convergence_map(config):
                                            resolution=config['resolution'])
 
     # Calculate the convergence map
-    convergence = kaiser_squires.ks_inversion(g1map, -g2map)
+    mode = config['mode']
+    if mode == 'E'
+        convergence = kaiser_squires.ks_e_mode_inversion(g1map, -g2map)
+    elif mode == 'B'
+        convergence = kaiser_squires.ks_b_mode_inversion(g1map, -g2map)
+    else
+        raise ValueError(f"Invalid mode: {mode}. Must be 'E' or 'B'.")
 
     # Save the convergence map as a FITS file (or not)
     utils.save_convergence_fits(convergence, boundaries, config)

--- a/SMPy/KaiserSquires/run.py
+++ b/SMPy/KaiserSquires/run.py
@@ -33,11 +33,11 @@ def create_convergence_map(config):
 
     # Calculate the convergence map
     mode = config['mode']
-    if mode == 'E'
+    if mode == 'E':
         convergence = kaiser_squires.ks_e_mode_inversion(g1map, -g2map)
-    elif mode == 'B'
+    elif mode == 'B':
         convergence = kaiser_squires.ks_b_mode_inversion(g1map, -g2map)
-    else
+    else:
         raise ValueError(f"Invalid mode: {mode}. Must be 'E' or 'B'.")
 
     # Save the convergence map as a FITS file (or not)


### PR DESCRIPTION
I added a function for the ks b mode inversion. I also renamed the e-mode function to specify its for the e-mode inversion. I was able to run this locally. I also made it so you can specify which map you want in the config. A B-mode map is attached. Let me know if you have any questions - I used paper 2 on this issue as a reference: [https://github.com/GeorgeVassilakis/SMPy/issues/13#issuecomment-2294424322](url)

![simulation_kmap](https://github.com/user-attachments/assets/f51f7242-2bb5-4ec9-8f1f-a22b41eec58e)
 